### PR TITLE
New rule: prefer-native-method (Fixes #221)

### DIFF
--- a/src/rules/prefer-native-method.js
+++ b/src/rules/prefer-native-method.js
@@ -30,7 +30,7 @@ module.exports = {
                     message: 'Prefer \'Array.prototype.map\' over the lodash function.',
                     fix(fixer) {
                         const [firstArg, ...restArgs] = node.arguments
-                        return fixer.replaceText(node, `${sourceCode.getText(firstArg)}.map(${restArgs.map(arg => sourceCode.getText(arg)).join(', ')})`)
+                        return fixer.replaceText(node, `(${sourceCode.getText(firstArg)}).map(${restArgs.map(arg => sourceCode.getText(arg)).join(', ')})`)
                     }
                 })
             }

--- a/tests/lib/rules/prefer-native-method.js
+++ b/tests/lib/rules/prefer-native-method.js
@@ -26,29 +26,36 @@ ruleTester.run('prefer-native-method', rule, {
     invalid: [{
         code: 'var x = _.map(arr, f)',
         errors: [{message: 'Prefer \'Array.prototype.map\' over the lodash function.'}],
-        output: 'var x = arr.map(f)'
+        output: 'var x = (arr).map(f)'
     }, {
         code: 'import {map} from "lodash"; var x = map(arr, f)',
         errors: [{message: 'Prefer \'Array.prototype.map\' over the lodash function.'}],
-        output: 'import {map} from "lodash"; var x = arr.map(f)',
+        output: 'import {map} from "lodash"; var x = (arr).map(f)',
         parserOptions: {
             sourceType: 'module'
         }
     }, {
         code: 'var x = _.map(arr, (i) => i)',
         errors: [{message: 'Prefer \'Array.prototype.map\' over the lodash function.'}],
-        output: 'var x = arr.map((i) => i)'
+        output: 'var x = (arr).map((i) => i)'
     }, {
         code: 'import {map as renamedMap} from "lodash"; var x = renamedMap(arr, (i) => i)',
         errors: [{message: 'Prefer \'Array.prototype.map\' over the lodash function.'}],
-        output: 'import {map as renamedMap} from "lodash"; var x = arr.map((i) => i)',
+        output: 'import {map as renamedMap} from "lodash"; var x = (arr).map((i) => i)',
         parserOptions: {
             sourceType: 'module'
         }
     }, {
         code: 'import {map as renamedMap} from "lodash"; var x = renamedMap(compact([1,2,3,null]), (i) => i)',
         errors: [{message: 'Prefer \'Array.prototype.map\' over the lodash function.'}],
-        output: 'import {map as renamedMap} from "lodash"; var x = compact([1,2,3,null]).map((i) => i)',
+        output: 'import {map as renamedMap} from "lodash"; var x = (compact([1,2,3,null])).map((i) => i)',
+        parserOptions: {
+            sourceType: 'module'
+        }
+    }, {
+        code: 'import {map} from "lodash"; var x = map(a ? b : c, (i) => i)',
+        errors: [{message: 'Prefer \'Array.prototype.map\' over the lodash function.'}],
+        output: 'import {map} from "lodash"; var x = (a ? b : c).map((i) => i)',
         parserOptions: {
             sourceType: 'module'
         }


### PR DESCRIPTION
Fixes #221

The new rule in its current state in this branch only works with `map` as a proof of concept.

The fix for this rule is unsafe as `_.map()` can accept any collection and not only Array. So it has the potential to break code such as:

```js
_.map({ a: 'c', b: 'd' }, (v, k) => whatever(v, k))
```

Open to feedback about how to get this rule actually in a state where it could be merged. Thanks