### PR TITLE
add prefer-is-empty rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ For example, Lodash collection methods (e.g. `map`, `forEach`) are generally fas
 * [prefer-constant](docs/rules/prefer-constant.md): Prefer `_.constant` over functions returning literals.
 * [prefer-get](docs/rules/prefer-get.md): Prefer using `_.get` or `_.has` over expression chains like `a && a.b && a.b.c`.
 * [prefer-includes](docs/rules/prefer-includes.md): Prefer `_.includes` over comparing `indexOf` to -1.
+* [prefer-is-empty](docs/rules/prefer-is-empty.md): Prefer `_.isEmpty` over manual checking for length value.
 * [prefer-is-nil](docs/rules/prefer-is-nil.md): Prefer `_.isNil` over checks for both null and undefined.
 * [prefer-lodash-chain](docs/rules/prefer-lodash-chain.md): Prefer using Lodash chains (e.g. `_.map`) over native and mixed chains.
 * [prefer-lodash-method](docs/rules/prefer-lodash-method.md): Prefer using Lodash collection methods (e.g. `_.map`) over native array methods.

--- a/docs/rules/prefer-is-empty.md
+++ b/docs/rules/prefer-is-empty.md
@@ -1,0 +1,39 @@
+# Prefer _.isEmpty
+
+When checking if a collection is empty or no, it is more concise to use _.isEmpty instead.
+
+## Rule Details
+
+This rule takes no arguments.
+
+The following patterns are considered warnings:
+
+```js
+const myLengthEqualZero = myVar.length === 0;
+
+const myLengthEqualZero = myVar.length > 0;
+
+const myLengthEqualZero = myVar.length > 0 ? "first" : "second";
+
+const myLengthEqualZero = myVar.myProp.mySecondProp.length === 0;
+
+const myLengthEqualZero = myVar.myProp.mySecondProp.length > 0;
+```
+
+The following patterns are not considered warnings:
+
+```js
+const myLengthEqualZero = !isEmpty(myVar);
+
+const myLengthEqualZero = isEmpty(myVar);
+
+const myLengthEqualZero = myVar.length == 0;
+
+const myLengthEqualZero = myVar.length;
+
+const myLengthEqualZero = myVar;
+```
+
+
+## When Not To Use It
+If you do not want to enforce using `_.isEmpty`, and prefer using native checks instead.

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ const recommended = {
         'lodash/prefer-immutable-method': 2,
         'lodash/prefer-includes': [2, {includeNative: true}],
         'lodash/prefer-invoke-map': 2,
-        'lodash-f/prefer-is-empty': 2,
+        'lodash/prefer-is-empty': 2,
         'lodash/prefer-is-nil': 2,
         'lodash/prefer-lodash-chain': 2,
         'lodash/prefer-lodash-method': 2,

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ const recommended = {
         'lodash/prefer-immutable-method': 2,
         'lodash/prefer-includes': [2, {includeNative: true}],
         'lodash/prefer-invoke-map': 2,
+        'lodash-f/prefer-is-empty': 2,
         'lodash/prefer-is-nil': 2,
         'lodash/prefer-lodash-chain': 2,
         'lodash/prefer-lodash-method': 2,

--- a/src/rules/prefer-is-empty.js
+++ b/src/rules/prefer-is-empty.js
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview Rule to prefer isEmpty over manual checking for length value.
+ */
+'use strict'
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const getDocsUrl = require('../util/getDocsUrl')
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        schema: [],
+        docs: {
+            url: getDocsUrl('prefer-is-empty')
+        },
+        fixable: 'code'
+    },
+
+    create(context) {
+        const {getLodashContext} = require('../util/lodashUtil')
+        const lodashContext = getLodashContext(context)
+
+        function getTextOfNode(node) {
+            if (node) {
+                if (node.type === 'Identifier') {
+                    return node.name
+                }
+                return context.getSourceCode().getText(node)
+            }
+        }
+
+        const visitors = lodashContext.getImportVisitors()
+        visitors.BinaryExpression = function (node) {
+            if (node.operator === '===') {
+                if (node.left.property) {
+                    const leftExpressionMember = node.left.property.name
+                    const rightExpressionMember = node.right.value
+                    if (leftExpressionMember === 'length' && rightExpressionMember === 0) {
+                        const subjectObject = node.left.object
+                        context.report({node, message: 'Prefer isEmpty over manually checking for length value.', fix(fixer) {
+                            return fixer.replaceText(node, `isEmpty(${getTextOfNode(subjectObject)})`)
+                        }})
+                    }
+                } else if (node.left.expression) {
+                    const leftExpressionMember = node.left.expression.property.name
+                    const rightExpressionMember = node.right.value
+                    if (leftExpressionMember === 'length' && rightExpressionMember === 0) {
+                        const subjectObject = node.left.expression.object
+                        context.report({node, message: 'Prefer isEmpty over manually checking for length value.', fix(fixer) {
+                            return fixer.replaceText(node, `isEmpty(${getTextOfNode(subjectObject)})`)
+                        }})
+                    }
+                }
+            }
+            if (node.operator === '>') {
+                if (node.left.property) {
+                    const leftExpressionMember = node.left.property.name
+                    const rightExpressionMember = node.right.value
+                    if (leftExpressionMember === 'length' && rightExpressionMember === 0) {
+                        const subjectObject = node.left.object
+                        context.report({node, message: 'Prefer isEmpty over manually checking for length value.', fix(fixer) {
+                            return fixer.replaceText(node, `!isEmpty(${getTextOfNode(subjectObject)})`)
+                        }})
+                    }
+                } else if (node.left.expression) {
+                    const leftExpressionMember = node.left.expression.property.name
+                    const rightExpressionMember = node.right.value
+                    if (leftExpressionMember === 'length' && rightExpressionMember === 0) {
+                        const subjectObject = node.left.expression.object
+                        context.report({node, message: 'Prefer isEmpty over manually checking for length value.', fix(fixer) {
+                            return fixer.replaceText(node, `!isEmpty(${getTextOfNode(subjectObject)})`)
+                        }})
+                    }
+                }
+            }
+        }
+        return visitors
+    }
+}

--- a/src/rules/prefer-is-empty.js
+++ b/src/rules/prefer-is-empty.js
@@ -35,45 +35,49 @@ module.exports = {
         const visitors = lodashContext.getImportVisitors()
         visitors.BinaryExpression = function (node) {
             if (node.operator === '===') {
-                if (node.left.property) {
-                    const leftExpressionMember = node.left.property.name
-                    const rightExpressionMember = node.right.value
-                    if (leftExpressionMember === 'length' && rightExpressionMember === 0) {
-                        const subjectObject = node.left.object
-                        context.report({node, message: 'Prefer isEmpty over manually checking for length value.', fix(fixer) {
-                            return fixer.replaceText(node, `isEmpty(${getTextOfNode(subjectObject)})`)
-                        }})
-                    }
-                } else if (node.left.expression) {
-                    const leftExpressionMember = node.left.expression.property.name
-                    const rightExpressionMember = node.right.value
-                    if (leftExpressionMember === 'length' && rightExpressionMember === 0) {
-                        const subjectObject = node.left.expression.object
-                        context.report({node, message: 'Prefer isEmpty over manually checking for length value.', fix(fixer) {
-                            return fixer.replaceText(node, `isEmpty(${getTextOfNode(subjectObject)})`)
-                        }})
+                if (node.left) {                    
+                    if (node.left.property && node.right) {
+                        const leftExpressionMember = node.left.property.name 
+                        const rightExpressionMember = node.right.value
+                        if (leftExpressionMember === 'length' && rightExpressionMember === 0) {
+                            const subjectObject = node.left.object
+                            context.report({node, message: 'Prefer isEmpty over manually checking for length value.', fix(fixer) {
+                                return fixer.replaceText(node, `isEmpty(${getTextOfNode(subjectObject)})`)
+                            }})
+                        }                    
+                    } else if (node.left.expression && node.right && node.left.expression.property) {
+                        const leftExpressionMember = node.left.expression.property.name 
+                        const rightExpressionMember = node.right.value
+                        if (leftExpressionMember === 'length' && rightExpressionMember === 0) {
+                            const subjectObject = node.left.expression.object
+                            context.report({node, message: 'Prefer isEmpty over manually checking for length value.', fix(fixer) {
+                                return fixer.replaceText(node, `isEmpty(${getTextOfNode(subjectObject)})`)
+                            }})
+                        }              
                     }
                 }
             }
             if (node.operator === '>') {
-                if (node.left.property) {
-                    const leftExpressionMember = node.left.property.name
-                    const rightExpressionMember = node.right.value
-                    if (leftExpressionMember === 'length' && rightExpressionMember === 0) {
-                        const subjectObject = node.left.object
-                        context.report({node, message: 'Prefer isEmpty over manually checking for length value.', fix(fixer) {
-                            return fixer.replaceText(node, `!isEmpty(${getTextOfNode(subjectObject)})`)
-                        }})
-                    }
-                } else if (node.left.expression) {
-                    const leftExpressionMember = node.left.expression.property.name
-                    const rightExpressionMember = node.right.value
-                    if (leftExpressionMember === 'length' && rightExpressionMember === 0) {
-                        const subjectObject = node.left.expression.object
-                        context.report({node, message: 'Prefer isEmpty over manually checking for length value.', fix(fixer) {
-                            return fixer.replaceText(node, `!isEmpty(${getTextOfNode(subjectObject)})`)
-                        }})
-                    }
+                if (node.left) {
+                    if (node.left.property && node.right) {
+                        const leftExpressionMember = node.left.property.name 
+                        const rightExpressionMember = node.right.value
+                        if (leftExpressionMember === 'length' && rightExpressionMember === 0) {
+                            const subjectObject = node.left.object
+                            context.report({node, message: 'Prefer isEmpty over manually checking for length value.', fix(fixer) {
+                                return fixer.replaceText(node, `!isEmpty(${getTextOfNode(subjectObject)})`)
+                            }})
+                        } 
+                    } else if (node.left.expression && node.right) {
+                        const leftExpressionMember = node.left.expression.property.name 
+                        const rightExpressionMember = node.right.value
+                        if (leftExpressionMember === 'length' && rightExpressionMember === 0) {
+                            const subjectObject = node.left.expression.object
+                            context.report({node, message: 'Prefer isEmpty over manually checking for length value.', fix(fixer) {
+                                return fixer.replaceText(node, `!isEmpty(${getTextOfNode(subjectObject)})`)
+                            }})
+                        }              
+                    }                    
                 }
             }
         }

--- a/tests/lib/rules/prefer-is-empty.js
+++ b/tests/lib/rules/prefer-is-empty.js
@@ -1,0 +1,44 @@
+'use strict'
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../src/rules/prefer-is-empty')
+const ruleTesterUtil = require('../testUtil/ruleTesterUtil')
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = ruleTesterUtil.getRuleTester()
+const {withDefaultPragma, fromMessage} = require('../testUtil/optionsUtil')
+const toErrorObject = fromMessage('Prefer isEmpty over manually checking for length value.')
+ruleTester.run('prefer-is-empty', rule, {
+    valid: [
+        'const myLengthEqualZero = !isEmpty(myVar);',
+        'const myLengthEqualZero = isEmpty(myVar);',
+        'const myLengthEqualZero = myVar.length == 0;',
+        'const myLengthEqualZero = myVar && myVar.length == 0;',
+        'const myLengthEqualZero = myVar.length;',
+        'const myLengthEqualZero = myVar;'
+    ].map(withDefaultPragma),
+    invalid: [
+        {code: 'const myLengthEqualZero = myVar.length === 0;', output: 'const myLengthEqualZero = isEmpty(myVar);'},
+        {code: 'const myLengthEqualZero = myVar.length > 0;', output: 'const myLengthEqualZero = !isEmpty(myVar);'},
+        {code: 'const myLengthEqualZero = myVar.length > 0 ? "first" : "second";', output: 'const myLengthEqualZero = !isEmpty(myVar) ? "first" : "second";'},
+        {code: 'const myLengthEqualZero = myVar.myProp.mySecondProp.length === 0;', output: 'const myLengthEqualZero = isEmpty(myVar.myProp.mySecondProp);'},
+        {code: 'const myLengthEqualZero = myVar.myProp.mySecondProp.length > 0;', output: 'const myLengthEqualZero = !isEmpty(myVar.myProp.mySecondProp);'},
+        {code: 'const myLengthEqualZero = myVar && myVar.myProp.mySecondProp.length > 0;', output: 'const myLengthEqualZero = myVar && !isEmpty(myVar.myProp.mySecondProp);'},
+        {code: 'const myLengthEqualZero = myVar[myProp].mySecondProp.length > 0;', output: 'const myLengthEqualZero = !isEmpty(myVar[myProp].mySecondProp);'},
+        {code: `
+        const xprop = "x"
+        const yprop = "y"
+        const myLengthWithOCWithProp = myvar[xprop].mySecondprop.myThirdProp[yprop].length > 0;
+        `, output: `
+        const xprop = "x"
+        const yprop = "y"
+        const myLengthWithOCWithProp = !isEmpty(myvar[xprop].mySecondprop.myThirdProp[yprop]);
+        `}
+    ].map(withDefaultPragma).map(toErrorObject)
+})

--- a/tests/lib/rules/prefer-is-empty.js
+++ b/tests/lib/rules/prefer-is-empty.js
@@ -29,7 +29,7 @@ ruleTester.run('prefer-is-empty', rule, {
         {code: 'const myLengthEqualZero = myVar.length > 0 ? "first" : "second";', output: 'const myLengthEqualZero = !isEmpty(myVar) ? "first" : "second";'},
         {code: 'const myLengthEqualZero = myVar.myProp.mySecondProp.length === 0;', output: 'const myLengthEqualZero = isEmpty(myVar.myProp.mySecondProp);'},
         {code: 'const myLengthEqualZero = myVar.myProp.mySecondProp.length > 0;', output: 'const myLengthEqualZero = !isEmpty(myVar.myProp.mySecondProp);'},
-        {code: 'const myLengthEqualZero = myVar && myVar.myProp.mySecondProp.length > 0;', output: 'const myLengthEqualZero = myVar && !isEmpty(myVar.myProp.mySecondProp);'},
+        {code: 'const myLengthEqualZero = myVar?.myProp.mySecondProp.length > 0;', output: 'const myLengthEqualZero = !isEmpty(myVar?.myProp.mySecondProp);', parserOptions: {ecmaVersion: 2020}},
         {code: 'const myLengthEqualZero = myVar[myProp].mySecondProp.length > 0;', output: 'const myLengthEqualZero = !isEmpty(myVar[myProp].mySecondProp);'},
         {code: `
         const xprop = "x"


### PR DESCRIPTION
Added prefer-is-empty rule. It enforces the use of isEmpty Lodash method over the native syntax. The rule is accompanied by tests.